### PR TITLE
V next

### DIFF
--- a/XLocalizer/DataAnnotations/DefaultDataAnnotationsErrorMessagesProvider.cs
+++ b/XLocalizer/DataAnnotations/DefaultDataAnnotationsErrorMessagesProvider.cs
@@ -1,0 +1,103 @@
+﻿namespace XLocalizer.DataAnnotations
+{
+    /// <summary>
+    /// Original messages obtained from <a href="https://github.com/dotnet/corefx/blob/master/src/System.ComponentModel.Annotations/src/Resources/Strings.resx"/>
+    /// </summary>
+    public class DefaultDataAnnotationsErrorMessagesProvider : IDataAnnotationsMessagesProvider
+    {
+        string IDataAnnotationsMessagesProvider.ArgumentIsNullOrWhitespace => "The argument '{0}' cannot be null, empty or contain only whitespace.";
+
+        string IDataAnnotationsMessagesProvider.AssociatedMetadataTypeTypeDescriptor_MetadataTypeContainsUnknownProperties => "The associated metadata type for type '{0}' contains the following unknown properties or fields: {1}. Please make sure that the names of these members match the names of the properties on the main type.";
+
+        string IDataAnnotationsMessagesProvider.AttributeStore_Unknown_Property => "The type '{0}' does not contain a public property named '{1}'.";
+
+        string IDataAnnotationsMessagesProvider.Common_PropertyNotFound => "The property {0}.{1} could not be found.";
+
+        string IDataAnnotationsMessagesProvider.CompareAttribute_MustMatch => "'{0}' and '{1}' do not match.";
+
+        string IDataAnnotationsMessagesProvider.CompareAttribute_UnknownProperty => "Could not find a property named {0}.";
+
+        string IDataAnnotationsMessagesProvider.CreditCardAttribute_Invalid => "The {0} field is not a valid credit card number.";
+
+        string IDataAnnotationsMessagesProvider.CustomValidationAttribute_Type_Conversion_Failed => "Could not convert the value of type '{0}' to '{1}' as expected by method {2}.{3}.";
+
+        string IDataAnnotationsMessagesProvider.CustomValidationAttribute_Type_Must_Be_Public => "The custom validation type '{0}' must be public.";
+
+        string IDataAnnotationsMessagesProvider.CustomValidationAttribute_ValidationError => "{0} is not valid.";
+
+        string IDataAnnotationsMessagesProvider.DataTypeAttribute_EmptyDataTypeString => "The custom DataType string cannot be null or empty.";
+
+        string IDataAnnotationsMessagesProvider.DisplayAttribute_PropertyNotSet => "The {0} property has not been set.  Use the {1} method to get the value.";
+
+        string IDataAnnotationsMessagesProvider.EmailAddressAttribute_Invalid => "The {0} field is not a valid e-mail address.";
+
+        string IDataAnnotationsMessagesProvider.EnumDataTypeAttribute_TypeCannotBeNull => "The type provided for EnumDataTypeAttribute cannot be null.";
+
+        string IDataAnnotationsMessagesProvider.EnumDataTypeAttribute_TypeNeedsToBeAnEnum => "The type '{0}' needs to represent an enumeration type.";
+
+        string IDataAnnotationsMessagesProvider.FileExtensionsAttribute_Invalid => "The {0} field only accepts files with the following extensions: {1}";
+
+        string IDataAnnotationsMessagesProvider.LengthAttribute_InvalidValueType => "The field of type {0} must be a string, array or ICollection type.";
+
+        string IDataAnnotationsMessagesProvider.MaxLengthAttribute_InvalidMaxLength => "MaxLengthAttribute must have a Length value that is greater than zero. Use MaxLength() without parameters to indicate that the string or array can have the maximum allowable length.";
+
+        string IDataAnnotationsMessagesProvider.MaxLengthAttribute_ValidationError => "The field {0} must be a string or array type with a maximum length of '{1}'.";
+
+        string IDataAnnotationsMessagesProvider.MetadataTypeAttribute_TypeCannotBeNull => "MetadataClassType cannot be null.";
+
+        string IDataAnnotationsMessagesProvider.MinLengthAttribute_InvalidMinLength => "MinLengthAttribute must have a Length value that is zero or greater.";
+
+        string IDataAnnotationsMessagesProvider.MinLengthAttribute_ValidationError => "The field {0} must be a string or array type with a minimum length of '{1}'.";
+
+        string IDataAnnotationsMessagesProvider.PhoneAttribute_Invalid => "The {0} field is not a valid phone number.";
+
+        string IDataAnnotationsMessagesProvider.RangeAttribute_ArbitraryTypeNotIComparable => "The type {0} must implement {1}.";
+
+        string IDataAnnotationsMessagesProvider.RangeAttribute_MinGreaterThanMax => "The maximum value '{0}' must be greater than or equal to the minimum value '{1}'.";
+
+        string IDataAnnotationsMessagesProvider.RangeAttribute_Must_Set_Min_And_Max => "The minimum and maximum values must be set.";
+
+        string IDataAnnotationsMessagesProvider.RangeAttribute_Must_Set_Operand_Type => "The OperandType must be set when strings are used for minimum and maximum values.";
+
+        string IDataAnnotationsMessagesProvider.RangeAttribute_ValidationError => "The field {0} must be between {1} and {2}.";
+
+        string IDataAnnotationsMessagesProvider.RegexAttribute_ValidationError => "The field {0} must match the regular expression '{1}'.";
+
+        string IDataAnnotationsMessagesProvider.RegularExpressionAttribute_Empty_Pattern => "The pattern must be set to a valid regular expression.";
+
+        string IDataAnnotationsMessagesProvider.RequiredAttribute_ValidationError => "The {0} field is required.";
+
+        string IDataAnnotationsMessagesProvider.StringLengthAttribute_InvalidMaxLength => "The maximum length must be a nonnegative integer.";
+
+        string IDataAnnotationsMessagesProvider.StringLengthAttribute_ValidationError => "The field {0} must be a string with a maximum length of {1}.";
+
+        string IDataAnnotationsMessagesProvider.StringLengthAttribute_ValidationErrorIncludingMinimum => "The field {0} must be a string with a minimum length of {2} and a maximum length of {1}.";
+
+
+        string IDataAnnotationsMessagesProvider.UIHintImplementation_ControlParameterKeyIsNotAString => "The key parameter at position {0} with value '{1}' is not a string. Every key control parameter must be a string.";
+
+        string IDataAnnotationsMessagesProvider.UIHintImplementation_ControlParameterKeyIsNull => "The key parameter at position {0} is null. Every key control parameter must be a string.";
+
+        string IDataAnnotationsMessagesProvider.UIHintImplementation_ControlParameterKeyOccursMoreThanOnce => "The key parameter at position {0} with value '{1}' occurs more than once.";
+
+        string IDataAnnotationsMessagesProvider.UIHintImplementation_NeedEvenNumberOfControlParameters => "The number of control parameters must be even.";
+
+        string IDataAnnotationsMessagesProvider.UrlAttribute_Invalid => "The {0} field is not a valid fully-qualified http, https, or ftp URL.";
+
+        string IDataAnnotationsMessagesProvider.ValidationAttribute_Cannot_Set_ErrorMessage_And_Resource => "Either ErrorMessageString or ErrorMessageResourceName must be set, but not both.";
+
+        string IDataAnnotationsMessagesProvider.ValidationAttribute_IsValid_NotImplemented => "IsValid(object value) has not been implemented by this class.  The preferred entry point is GetValidationResult() and classes should override IsValid(object value, ValidationContext context).";
+
+        string IDataAnnotationsMessagesProvider.ValidationAttribute_NeedBothResourceTypeAndResourceName => "Both ErrorMessageResourceType and ErrorMessageResourceName need to be set on this attribute.";
+
+        string IDataAnnotationsMessagesProvider.ValidationAttribute_ResourcePropertyNotStringType => "The property '{0}' on resource type '{1}' is not a string type.";
+
+        string IDataAnnotationsMessagesProvider.ValidationAttribute_ResourceTypeDoesNotHaveProperty => "The resource type '{0}' does not have an accessible static property named '{1}'.";
+
+        string IDataAnnotationsMessagesProvider.ValidationAttribute_ValidationError => "The field {0} is invalid.";
+
+        string IDataAnnotationsMessagesProvider.Validator_InstanceMustMatchValidationContextInstance => "The instance provided must match the ObjectInstance on the ValidationContext supplied.";
+
+        string IDataAnnotationsMessagesProvider.Validator_Property_Value_Wrong_Type => "The value for property '{0}' must be of type '{1}'.";
+    }
+}

--- a/XLocalizer/DataAnnotations/IDataAnnotationsMessagesProvider.cs
+++ b/XLocalizer/DataAnnotations/IDataAnnotationsMessagesProvider.cs
@@ -1,0 +1,246 @@
+﻿namespace XLocalizer.DataAnnotations
+{
+    /// <summary>
+    /// Interface to provide custom default data annotation error messages.
+    /// Messages can be provided in any culture, so user can provide localized error messages here,
+    /// but the default request culture in startup must be configured same as messages culture.
+    /// </summary>
+    public interface IDataAnnotationsMessagesProvider
+    {
+        /// <summary>
+        /// The argument '{0}' cannot be null, empty or contain only whitespace.
+        /// </summary>
+        string ArgumentIsNullOrWhitespace { get; }
+
+        /// <summary>
+        /// The associated metadata type for type '{0}' contains the following unknown properties or fields: {1}. Please make sure that the names of these members match the names of the properties on the main type.
+        /// </summary>
+        string AssociatedMetadataTypeTypeDescriptor_MetadataTypeContainsUnknownProperties { get; }
+
+        /// <summary>
+        /// The type '{0}' does not contain a property named '{1}'.
+        /// </summary>
+        string AttributeStore_Unknown_Property { get; }
+
+        /// <summary>
+        /// The property {0}.{1} could not be found.
+        /// </summary>
+        string Common_PropertyNotFound { get; }
+
+        /// <summary>
+        /// '{0}' and '{1}' do not match.
+        /// </summary>
+        string CompareAttribute_MustMatch { get; }
+
+        /// <summary>
+        /// Could not find a property named {0}.
+        /// </summary>
+        string CompareAttribute_UnknownProperty { get; }
+
+        /// <summary>
+        /// The {0} field is not a valid credit card number.
+        /// </summary>
+        string CreditCardAttribute_Invalid { get; }
+
+        /// <summary>
+        /// Could not convert the value of type '{0}' to '{1}' as expected by method {2}.{3}.
+        /// </summary>
+        string CustomValidationAttribute_Type_Conversion_Failed { get; }
+
+        /// <summary>
+        /// The custom validation type '{0}' must be public.
+        /// </summary>
+        string CustomValidationAttribute_Type_Must_Be_Public { get; }
+
+        /// <summary>
+        /// {0} is not valid.
+        /// </summary>
+        string CustomValidationAttribute_ValidationError { get; }
+
+        /// <summary>
+        /// The custom DataType string cannot be null or empty.
+        /// </summary>
+        string DataTypeAttribute_EmptyDataTypeString { get; }
+
+        /// <summary>
+        /// The {0} property has not been set.  Use the {1} method to get the value.
+        /// </summary>
+        string DisplayAttribute_PropertyNotSet { get; }
+
+        /// <summary>
+        /// The {0} field is not a valid e-mail address.
+        /// </summary>
+        string EmailAddressAttribute_Invalid { get; }
+
+        /// <summary>
+        /// The type provided for EnumDataTypeAttribute cannot be null.
+        /// </summary>
+        string EnumDataTypeAttribute_TypeCannotBeNull { get; }
+
+        /// <summary>
+        /// The type '{0}' needs to represent an enumeration type.
+        /// </summary>
+        string EnumDataTypeAttribute_TypeNeedsToBeAnEnum { get; }
+
+        /// <summary>
+        /// The {0} field only accepts files with the following extensions: {1}
+        /// </summary>
+        string FileExtensionsAttribute_Invalid { get; }
+
+        /// <summary>
+        /// The field of type {0} must be a string, array or ICollection type.
+        /// </summary>
+        string LengthAttribute_InvalidValueType { get; }
+
+
+        /// <summary>
+        /// MaxLengthAttribute must have a Length value that is greater than zero. Use MaxLength() without parameters to indicate that the string or array can have the maximum allowable length.
+        /// </summary>
+        string MaxLengthAttribute_InvalidMaxLength { get; }
+
+        /// <summary>
+        /// The field {0} must be a string or array type with a maximum length of '{1}'.
+        /// </summary>
+        string MaxLengthAttribute_ValidationError { get; }
+
+        /// <summary>
+        /// MetadataClassType cannot be null.
+        /// </summary>
+        string MetadataTypeAttribute_TypeCannotBeNull { get; }
+
+        /// <summary>
+        /// MinLengthAttribute must have a Length value that is zero or greater.
+        /// </summary>
+        string MinLengthAttribute_InvalidMinLength { get; }
+
+        /// <summary>
+        /// The field {0} must be a string or array type with a minimum length of '{1}'.
+        /// </summary>
+        string MinLengthAttribute_ValidationError { get; }
+
+        /// <summary>
+        /// The {0} field is not a valid phone number.
+        /// </summary>
+        string PhoneAttribute_Invalid { get; }
+
+        /// <summary>
+        /// The type {0} must implement {1}.
+        /// </summary>
+        string RangeAttribute_ArbitraryTypeNotIComparable { get; }
+
+        /// <summary>
+        /// The maximum value '{0}' must be greater than or equal to the minimum value '{1}'.
+        /// </summary>
+        string RangeAttribute_MinGreaterThanMax { get; }
+
+        /// <summary>
+        /// The minimum and maximum values must be set.
+        /// </summary>
+        string RangeAttribute_Must_Set_Min_And_Max { get; }
+
+        /// <summary>
+        /// The OperandType must be set when strings are used for minimum and maximum values.
+        /// </summary>
+        string RangeAttribute_Must_Set_Operand_Type { get; }
+
+        /// <summary>
+        /// The field {0} must be between {1} and {2}.
+        /// </summary>
+        string RangeAttribute_ValidationError { get; }
+
+        /// <summary>
+        /// The field {0} must match the regular expression '{1}'.
+        /// </summary>
+        string RegexAttribute_ValidationError { get; }
+
+        /// <summary>
+        /// The pattern must be set to a valid regular expression.
+        /// </summary>
+        string RegularExpressionAttribute_Empty_Pattern { get; }
+
+        /// <summary>
+        /// The {0} field is required.
+        /// </summary>
+        string RequiredAttribute_ValidationError { get; }
+
+        /// <summary>
+        /// The maximum length must be a nonnegative integer.
+        /// </summary>
+        string StringLengthAttribute_InvalidMaxLength { get; }
+
+        /// <summary>
+        /// The field {0} must be a string with a maximum length of {1}.
+        /// </summary>
+        string StringLengthAttribute_ValidationError { get; }
+
+        /// <summary>
+        /// The field {0} must be a string with a minimum length of {2} and a maximum length of {1}.
+        /// </summary>
+        string StringLengthAttribute_ValidationErrorIncludingMinimum { get; }
+
+        /// <summary>
+        /// The key parameter at position {0} with value '{1}' is not a string. Every key control parameter must be a string.
+        /// </summary>
+        string UIHintImplementation_ControlParameterKeyIsNotAString { get; }
+
+        /// <summary>
+        /// The key parameter at position {0} is null. Every key control parameter must be a string.
+        /// </summary>
+        string UIHintImplementation_ControlParameterKeyIsNull { get; }
+
+        /// <summary>
+        /// The key parameter at position {0} with value '{1}' occurs more than once.
+        /// </summary>
+        string UIHintImplementation_ControlParameterKeyOccursMoreThanOnce { get; }
+
+        /// <summary>
+        /// The number of control parameters must be even.
+        /// </summary>
+        string UIHintImplementation_NeedEvenNumberOfControlParameters { get; }
+
+        /// <summary>
+        /// The {0} field is not a valid fully-qualified http, https, or ftp URL.
+        /// </summary>
+        string UrlAttribute_Invalid { get; }
+
+        /// <summary>
+        /// Either ErrorMessageString or ErrorMessageResourceName must be set, but not both.
+        /// </summary>
+        string ValidationAttribute_Cannot_Set_ErrorMessage_And_Resource { get; }
+
+        /// <summary>
+        /// IsValid(object value) has not been implemented by this class.  The preferred entry point is GetValidationResult() and classes should override IsValid(object value, ValidationContext context).
+        /// </summary>
+        string ValidationAttribute_IsValid_NotImplemented { get; }
+
+        /// <summary>
+        /// Both ErrorMessageResourceType and ErrorMessageResourceName need to be set on this attribute.
+        /// </summary>
+        string ValidationAttribute_NeedBothResourceTypeAndResourceName { get; }
+
+        /// <summary>
+        /// The property '{0}' on resource type '{1}' is not a string type.
+        /// </summary>
+        string ValidationAttribute_ResourcePropertyNotStringType { get; }
+
+        /// <summary>
+        /// The resource type '{0}' does not have an accessible static property named '{1}'.
+        /// </summary>
+        string ValidationAttribute_ResourceTypeDoesNotHaveProperty { get; }
+
+        /// <summary>
+        /// The field {0} is invalid.
+        /// </summary>
+        string ValidationAttribute_ValidationError { get; }
+
+        /// <summary>
+        /// The instance provided must match the ObjectInstance on the ValidationContext supplied.
+        /// </summary>
+        string Validator_InstanceMustMatchValidationContextInstance { get; }
+
+        /// <summary>
+        /// The value for property '{0}' must be of type '{1}'.
+        /// </summary>
+        string Validator_Property_Value_Wrong_Type { get; }
+    }
+}

--- a/XLocalizer/Identity/DefaultIdentityErrorsProvider.cs
+++ b/XLocalizer/Identity/DefaultIdentityErrorsProvider.cs
@@ -1,0 +1,52 @@
+﻿namespace XLocalizer.Identity
+{
+    /// <summary>
+    /// Default identity errors provider
+    /// </summary>
+    public class DefaultIdentityErrorsProvider : IIdentityErrorMessagesProvider
+    {
+        string IIdentityErrorMessagesProvider.DuplicateEmail => "Email '{0}' is already taken.";
+
+        string IIdentityErrorMessagesProvider.DuplicateUserName => "User name '{0}' is already taken.";
+
+        string IIdentityErrorMessagesProvider.InvalidEmail => "Email '{0}' is invalid.";
+
+        string IIdentityErrorMessagesProvider.DuplicateRoleName => "Role name '{0}' is already taken.";
+
+        string IIdentityErrorMessagesProvider.InvalidRoleName => "Role name '{0}' is invalid.";
+
+        string IIdentityErrorMessagesProvider.InvalidToken => "Invalid token.";
+
+        string IIdentityErrorMessagesProvider.InvalidUserName => "User name '{0}' is invalid, can only contain letters or digits.";
+
+        string IIdentityErrorMessagesProvider.LoginAlreadyAssociated => "A user with this login already exists.";
+
+        string IIdentityErrorMessagesProvider.PasswordMismatch => "Incorrect password.";
+
+        string IIdentityErrorMessagesProvider.PasswordRequiresDigit => "Passwords must have at least one digit ('0'-'9').";
+
+        string IIdentityErrorMessagesProvider.PasswordRequiresLower => "Passwords must have at least one lowercase ('a'-'z').";
+
+        string IIdentityErrorMessagesProvider.PasswordRequiresNonAlphanumeric => "Passwords must have at least one non alphanumeric character.";
+
+        string IIdentityErrorMessagesProvider.PasswordRequiresUniqueChars => "Passwords must use at least {0} different characters.";
+
+        string IIdentityErrorMessagesProvider.PasswordRequiresUpper => "Passwords must have at least one uppercase ('A'-'Z').";
+
+        string IIdentityErrorMessagesProvider.PasswordTooShort => "Passwords must be at least {0} characters.";
+
+        string IIdentityErrorMessagesProvider.UserAlreadyHasPassword => "User already has a password set.";
+
+        string IIdentityErrorMessagesProvider.UserAlreadyInRole => "User already in role '{0}'.";
+
+        string IIdentityErrorMessagesProvider.UserNotInRole => "User is not in role '{0}'.";
+
+        string IIdentityErrorMessagesProvider.UserLockoutNotEnabled => "Lockout is not enabled for this user.";
+
+        string IIdentityErrorMessagesProvider.RecoveryCodeRedemptionFailed => "Recovery code redemption failed.";
+
+        string IIdentityErrorMessagesProvider.ConcurrencyFailure => "Optimistic concurrency failure, object has been modified.";
+
+        string IIdentityErrorMessagesProvider.DefaultError => "An unknown failure has occurred.";
+    }
+}

--- a/XLocalizer/Identity/DependencyInjection.cs
+++ b/XLocalizer/Identity/DependencyInjection.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace XLocalizer.Identity
 {
@@ -15,6 +16,8 @@ namespace XLocalizer.Identity
         /// <returns></returns>
         public static IMvcBuilder AddIdentityErrorsLocalization(this IMvcBuilder builder)
         {
+            builder.Services.TryAddSingleton<IIdentityErrorMessagesProvider, DefaultIdentityErrorsProvider>();
+
             // Add Identity Erros localization
             builder.Services.AddScoped<IdentityErrorDescriber, IdentityErrorsLocalizer>();
 

--- a/XLocalizer/Identity/IIdentityErrorMessagesProvider.cs
+++ b/XLocalizer/Identity/IIdentityErrorMessagesProvider.cs
@@ -1,0 +1,120 @@
+﻿namespace XLocalizer.Identity
+{
+    /// <summary>
+    /// Interface to provide custom default identity error messages.
+    /// Messages can be provided in any culture, so user can provide localized error messages here,
+    /// but the default request culture in startup must be configured same as messages culture.
+    /// </summary>
+    public interface IIdentityErrorMessagesProvider
+    {
+        /// <summary>
+        /// "Email '{0}' is already taken."
+        /// </summary>
+        string DuplicateEmail { get; }
+
+        /// <summary>
+        /// "User name '{0}' is already taken."
+        /// </summary>
+        string DuplicateUserName { get; }
+
+        /// <summary>
+        /// "Email '{0}' is invalid."
+        /// </summary>
+        string InvalidEmail { get; }
+
+        /// <summary>
+        /// "Role name '{0}' is already taken."
+        /// </summary>
+        string DuplicateRoleName { get; }
+
+        /// <summary>
+        /// "Role name '{0}' is invalid."
+        /// </summary>
+        string InvalidRoleName { get; }
+
+        /// <summary>
+        /// "Invalid token."
+        /// </summary>
+        string InvalidToken { get; }
+
+        /// <summary>
+        /// "User name '{0}' is invalid, can only contain letters or digits."
+        /// </summary>
+        string InvalidUserName { get; }
+
+        /// <summary>
+        /// "A user with this login already exists."
+        /// </summary>
+        string LoginAlreadyAssociated { get; }
+
+        /// <summary>
+        /// "Incorrect password."
+        /// </summary>
+        string PasswordMismatch { get; }
+
+        /// <summary>
+        /// "Passwords must have at least one digit ('0'-'9')."
+        /// </summary>
+        string PasswordRequiresDigit { get; }
+
+        /// <summary>
+        /// "Passwords must have at least one lowercase ('a'-'z')."
+        /// </summary>
+        string PasswordRequiresLower { get; }
+
+        /// <summary>
+        /// "Passwords must have at least one non alphanumeric character."
+        /// </summary>
+        string PasswordRequiresNonAlphanumeric { get; }
+
+        /// <summary>
+        /// "Passwords must use at least {0} different characters."
+        /// </summary>
+        string PasswordRequiresUniqueChars { get; }
+
+        /// <summary>
+        /// "Passwords must have at least one uppercase ('A'-'Z')."
+        /// </summary>
+        string PasswordRequiresUpper { get; }
+
+        /// <summary>
+        /// "Passwords must be at least {0} characters."
+        /// </summary>
+        string PasswordTooShort { get; }
+
+        /// <summary>
+        /// "User already has a password set."
+        /// </summary>
+        string UserAlreadyHasPassword { get; }
+
+        /// <summary>
+        /// "User already in role '{0}'."
+        /// </summary>
+        string UserAlreadyInRole { get; }
+
+        /// <summary>
+        /// "User is not in role '{0}'."
+        /// </summary>
+        string UserNotInRole { get; }
+
+        /// <summary>
+        /// "Lockout is not enabled for this user."
+        /// </summary>
+        string UserLockoutNotEnabled { get; }
+
+        /// <summary>
+        /// "Recovery code redemption failed."
+        /// </summary>
+        string RecoveryCodeRedemptionFailed { get; }
+
+        /// <summary>
+        /// "Optimistic concurrency failure, object has been modified."
+        /// </summary>
+        string ConcurrencyFailure { get; }
+
+        /// <summary>
+        /// "An unknown failure has occurred."
+        /// </summary>
+        string DefaultError { get; }
+    }
+}

--- a/XLocalizer/Identity/IdentityErrorsLocalizer.cs
+++ b/XLocalizer/Identity/IdentityErrorsLocalizer.cs
@@ -9,20 +9,23 @@ namespace XLocalizer.Identity
     /// </summary>
     public class IdentityErrorsLocalizer : IdentityErrorDescriber 
     {
-        private readonly IStringLocalizer Localizer;
+        private readonly IStringLocalizer _localizer;
+        private readonly IIdentityErrorMessagesProvider _errProvider;
                 
         /// <summary>
         /// Initialize identity erroors localization based on DB locailzer
         /// </summary>
         /// <param name="localizer"></param>
-        public IdentityErrorsLocalizer(IStringLocalizer localizer)
+        /// <param name="errProvider"></param>
+        public IdentityErrorsLocalizer(IStringLocalizer localizer, IIdentityErrorMessagesProvider errProvider)
         {
-            Localizer = localizer;
+            _localizer = localizer;
+            _errProvider = errProvider;
         }
 
         private IdentityError LocalizedIdentityError(string code, params object[] args)
         {
-            var msg = Localizer[code, args];
+            var msg = _localizer[code, args];
 
             return new IdentityError { Code = code, Description = msg };
         }
@@ -33,7 +36,7 @@ namespace XLocalizer.Identity
         /// <param name="email"></param>
         /// <returns></returns>
         public override IdentityError DuplicateEmail(string email) 
-            => LocalizedIdentityError("Email '{0}' is already taken.", email);
+            => LocalizedIdentityError(_errProvider.DuplicateEmail, email);
 
         /// <summary>
         /// "User name '{0}' is already taken."
@@ -41,7 +44,7 @@ namespace XLocalizer.Identity
         /// <param name="userName"></param>
         /// <returns></returns>
         public override IdentityError DuplicateUserName(string userName) 
-            => LocalizedIdentityError("User name '{0}' is already taken.", userName);
+            => LocalizedIdentityError(_errProvider.DuplicateUserName, userName);
 
         /// <summary>
         /// "Email '{0}' is invalid."
@@ -49,7 +52,7 @@ namespace XLocalizer.Identity
         /// <param name="email"></param>
         /// <returns></returns>
         public override IdentityError InvalidEmail(string email) 
-            => LocalizedIdentityError("Email '{0}' is invalid.", email);
+            => LocalizedIdentityError(_errProvider.InvalidEmail, email);
 
         /// <summary>
         /// "Role name '{0}' is already taken."
@@ -57,7 +60,7 @@ namespace XLocalizer.Identity
         /// <param name="role"></param>
         /// <returns></returns>
         public override IdentityError DuplicateRoleName(string role) 
-            => LocalizedIdentityError("Role name '{0}' is already taken.", role);
+            => LocalizedIdentityError(_errProvider.DuplicateRoleName, role);
 
         /// <summary>
         /// "Role name '{0}' is invalid."
@@ -65,14 +68,14 @@ namespace XLocalizer.Identity
         /// <param name="role"></param>
         /// <returns></returns>
         public override IdentityError InvalidRoleName(string role) 
-            => LocalizedIdentityError("Role name '{0}' is invalid.", role);
+            => LocalizedIdentityError(_errProvider.InvalidRoleName, role);
 
         /// <summary>
         /// "Invalid token."
         /// </summary>
         /// <returns></returns>
         public override IdentityError InvalidToken() 
-            => LocalizedIdentityError("Invalid token.");
+            => LocalizedIdentityError(_errProvider.InvalidToken);
 
         /// <summary>
         /// "User name '{0}' is invalid, can only contain letters or digits."
@@ -80,42 +83,42 @@ namespace XLocalizer.Identity
         /// <param name="userName"></param>
         /// <returns></returns>
         public override IdentityError InvalidUserName(string userName) 
-            => LocalizedIdentityError("User name '{0}' is invalid, can only contain letters or digits.", userName);
+            => LocalizedIdentityError(_errProvider.InvalidUserName, userName);
 
         /// <summary>
         /// "A user with this login already exists."
         /// </summary>
         /// <returns></returns>
         public override IdentityError LoginAlreadyAssociated() 
-            => LocalizedIdentityError("A user with this login already exists.");
+            => LocalizedIdentityError(_errProvider.LoginAlreadyAssociated);
 
         /// <summary>
         /// "Incorrect password."
         /// </summary>
         /// <returns></returns>
         public override IdentityError PasswordMismatch() 
-            => LocalizedIdentityError("Incorrect password.");
+            => LocalizedIdentityError(_errProvider.PasswordMismatch);
 
         /// <summary>
         /// "Passwords must have at least one digit ('0'-'9')."
         /// </summary>
         /// <returns></returns>
         public override IdentityError PasswordRequiresDigit() 
-            => LocalizedIdentityError("Passwords must have at least one digit ('0'-'9').");
+            => LocalizedIdentityError(_errProvider.PasswordRequiresDigit);
 
         /// <summary>
         /// "Passwords must have at least one lowercase ('a'-'z')."
         /// </summary>
         /// <returns></returns>
         public override IdentityError PasswordRequiresLower() 
-            => LocalizedIdentityError("Passwords must have at least one lowercase ('a'-'z').");
+            => LocalizedIdentityError(_errProvider.PasswordRequiresLower);
 
         /// <summary>
         /// "Passwords must have at least one non alphanumeric character."
         /// </summary>
         /// <returns></returns>
         public override IdentityError PasswordRequiresNonAlphanumeric() 
-            => LocalizedIdentityError("Passwords must have at least one non alphanumeric character.");
+            => LocalizedIdentityError(_errProvider.PasswordRequiresNonAlphanumeric);
 
         /// <summary>
         /// "Passwords must use at least {0} different characters."
@@ -123,14 +126,14 @@ namespace XLocalizer.Identity
         /// <param name="uniqueChars"></param>
         /// <returns></returns>
         public override IdentityError PasswordRequiresUniqueChars(int uniqueChars) 
-            => LocalizedIdentityError("Passwords must use at least {0} different characters.", uniqueChars);
+            => LocalizedIdentityError(_errProvider.PasswordRequiresUniqueChars, uniqueChars);
 
         /// <summary>
         /// "Passwords must have at least one uppercase ('A'-'Z')."
         /// </summary>
         /// <returns></returns>
         public override IdentityError PasswordRequiresUpper() 
-            => LocalizedIdentityError("Passwords must have at least one uppercase ('A'-'Z').");
+            => LocalizedIdentityError(_errProvider.PasswordRequiresUpper);
 
         /// <summary>
         /// "Passwords must be at least {0} characters."
@@ -138,14 +141,14 @@ namespace XLocalizer.Identity
         /// <param name="length"></param>
         /// <returns></returns>
         public override IdentityError PasswordTooShort(int length) 
-            => LocalizedIdentityError("Passwords must be at least {0} characters.", length);
+            => LocalizedIdentityError(_errProvider.PasswordTooShort, length);
 
         /// <summary>
         /// "User already has a password set."
         /// </summary>
         /// <returns></returns>
         public override IdentityError UserAlreadyHasPassword() 
-            => LocalizedIdentityError("User already has a password set.");
+            => LocalizedIdentityError(_errProvider.UserAlreadyHasPassword);
 
         /// <summary>
         /// "User already in role '{0}'."
@@ -153,7 +156,7 @@ namespace XLocalizer.Identity
         /// <param name="role"></param>
         /// <returns></returns>
         public override IdentityError UserAlreadyInRole(string role) 
-            => LocalizedIdentityError("User already in role '{0}'.", role);
+            => LocalizedIdentityError(_errProvider.UserAlreadyInRole, role);
 
         /// <summary>
         /// "User is not in role '{0}'."
@@ -161,34 +164,34 @@ namespace XLocalizer.Identity
         /// <param name="role"></param>
         /// <returns></returns>
         public override IdentityError UserNotInRole(string role) 
-            => LocalizedIdentityError("User is not in role '{0}'.", role);
+            => LocalizedIdentityError(_errProvider.UserNotInRole, role);
 
         /// <summary>
         /// "Lockout is not enabled for this user."
         /// </summary>
         /// <returns></returns>
         public override IdentityError UserLockoutNotEnabled() 
-            => LocalizedIdentityError("Lockout is not enabled for this user.");
+            => LocalizedIdentityError(_errProvider.UserLockoutNotEnabled);
 
         /// <summary>
         /// "Recovery code redemption failed."
         /// </summary>
         /// <returns></returns>
         public override IdentityError RecoveryCodeRedemptionFailed() 
-            => LocalizedIdentityError("Recovery code redemption failed.");
+            => LocalizedIdentityError(_errProvider.RecoveryCodeRedemptionFailed);
 
         /// <summary>
         /// "Optimistic concurrency failure, object has been modified."
         /// </summary>
         /// <returns></returns>
         public override IdentityError ConcurrencyFailure() 
-            => LocalizedIdentityError("Optimistic concurrency failure, object has been modified.");
+            => LocalizedIdentityError(_errProvider.ConcurrencyFailure);
 
         /// <summary>
         /// "An unknown failure has occurred."
         /// </summary>
         /// <returns></returns>
         public override IdentityError DefaultError() 
-            => LocalizedIdentityError("An unknown failure has occurred.");
+            => LocalizedIdentityError(_errProvider.DefaultError);
     }
 }

--- a/XLocalizer/ModelBinding/DefaultModelBindingErrorMessagesProvider.cs
+++ b/XLocalizer/ModelBinding/DefaultModelBindingErrorMessagesProvider.cs
@@ -1,0 +1,32 @@
+﻿namespace XLocalizer.ModelBinding
+{
+    /// <summary>
+    /// Class to provide custom default model binding error messages.
+    /// Messages can be provided in any culture, so user can provide localized error messages here,
+    /// but the default request culture in startup must be configured same as messages culture.
+    /// </summary>
+    public class DefaultModelBindingErrorMessagesProvider : IModelBindingErrorMessagesProvider
+    {
+        string IModelBindingErrorMessagesProvider.AttemptedValueIsInvalidAccessor => "The value '{0}' is not valid for {1}.";
+
+        string IModelBindingErrorMessagesProvider.MissingBindRequiredValueAccessor => "A value for the '{0}' parameter or property was not provided.";
+
+        string IModelBindingErrorMessagesProvider.MissingKeyOrValueAccessor => "A value is required.";
+
+        string IModelBindingErrorMessagesProvider.MissingRequestBodyRequiredValueAccessor => "A non-empty request body is required.";
+
+        string IModelBindingErrorMessagesProvider.NonPropertyAttemptedValueIsInvalidAccessor => "The value '{0}' is not valid.";
+
+        string IModelBindingErrorMessagesProvider.NonPropertyUnknownValueIsInvalidAccessor => "The supplied value is invalid.";
+
+        string IModelBindingErrorMessagesProvider.NonPropertyValueMustBeANumberAccessor => "The field must be a number.";
+
+        string IModelBindingErrorMessagesProvider.UnknownValueIsInvalidAccessor => "The supplied value is invalid for {0}.";
+
+        string IModelBindingErrorMessagesProvider.ValueIsInvalidAccessor => "The value '{0}' is invalid.";
+
+        string IModelBindingErrorMessagesProvider.ValueMustBeANumberAccessor => "The field {0} must be a number.";
+
+        string IModelBindingErrorMessagesProvider.ValueMustNotBeNullAccessor => "The value '{0}' is invalid.";
+    }
+}

--- a/XLocalizer/ModelBinding/DependencyInjection.cs
+++ b/XLocalizer/ModelBinding/DependencyInjection.cs
@@ -1,6 +1,6 @@
-﻿using XLocalizer.Common;
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace XLocalizer.ModelBinding
 {
@@ -16,12 +16,20 @@ namespace XLocalizer.ModelBinding
         /// <returns></returns>
         public static IMvcBuilder AddModelBindingLocalization(this IMvcBuilder builder)
         {
+            // Try register a service for providing default model binding error messages
+            builder.Services.TryAddSingleton<IModelBindingErrorMessagesProvider, DefaultModelBindingErrorMessagesProvider>();
+
             // Add ModelBinding errors localization
             builder.AddMvcOptions(ops =>
             {
-                var localizer = builder.Services.BuildServiceProvider().GetService(typeof(IStringLocalizer)) as IStringLocalizer;
-                ops.ModelBindingMessageProvider.SetLocalizedModelBindingErrorMessages(localizer);
+                var serviceBuilder = builder.Services.BuildServiceProvider();
+
+                var localizer = serviceBuilder.GetRequiredService(typeof(IStringLocalizer)) as IStringLocalizer;
+                var mbErrMsgProvider = serviceBuilder.GetRequiredService(typeof(IModelBindingErrorMessagesProvider)) as IModelBindingErrorMessagesProvider;
+
+                ops.ModelBindingMessageProvider.SetLocalizedModelBindingErrorMessages(localizer, mbErrMsgProvider);
             });
+
 
             return builder;
         }

--- a/XLocalizer/ModelBinding/IModelBindingErrorMessagesProvider.cs
+++ b/XLocalizer/ModelBinding/IModelBindingErrorMessagesProvider.cs
@@ -1,0 +1,65 @@
+﻿namespace XLocalizer.ModelBinding
+{
+    /// <summary>
+    /// Interface to provide custom default model binding error messages.
+    /// Messages can be provided in any culture, so user can provide localized error messages here,
+    /// but the default request culture in startup must be configured same as messages culture.
+    /// </summary>
+    public interface IModelBindingErrorMessagesProvider
+    {
+        /// <summary>
+        /// "The value '{0}' is not valid for {1}."
+        /// </summary>
+        string AttemptedValueIsInvalidAccessor { get; }
+
+        /// <summary>
+        /// "A value for the '{0}' parameter or property was not provided."
+        /// </summary>
+        string MissingBindRequiredValueAccessor { get; }
+
+        /// <summary>
+        /// "A value is required."
+        /// </summary>
+        string MissingKeyOrValueAccessor { get; }
+
+        /// <summary>
+        /// "A non-empty request body is required."
+        /// </summary>
+        string MissingRequestBodyRequiredValueAccessor { get; }
+
+        /// <summary>
+        /// "The value '{0}' is not valid."
+        /// </summary>
+        string NonPropertyAttemptedValueIsInvalidAccessor { get; }
+
+        /// <summary>
+        /// "The supplied value is invalid."
+        /// </summary>
+        string NonPropertyUnknownValueIsInvalidAccessor { get; }
+
+        /// <summary>
+        /// "The field must be a number."
+        /// </summary>
+        string NonPropertyValueMustBeANumberAccessor { get; }
+
+        /// <summary>
+        /// "The supplied value is invalid for {0}."
+        /// </summary>
+        string UnknownValueIsInvalidAccessor { get; }
+
+        /// <summary>
+        /// "The value '{0}' is invalid."
+        /// </summary>
+        string ValueIsInvalidAccessor { get; }
+
+        /// <summary>
+        /// "The field {0} must be a number."
+        /// </summary>
+        string ValueMustBeANumberAccessor { get; }
+
+        /// <summary>
+        /// "The value '{0}' is invalid."
+        /// </summary>
+        string ValueMustNotBeNullAccessor { get; }
+    }
+}

--- a/XLocalizer/ModelBinding/ModelBindingErrorsExtensions.cs
+++ b/XLocalizer/ModelBinding/ModelBindingErrorsExtensions.cs
@@ -13,40 +13,41 @@ namespace XLocalizer.ModelBinding
         /// </summary>
         /// <param name="provider"></param>
         /// <param name="localizer">localizer factory</param>
-        public static void SetLocalizedModelBindingErrorMessages(this DefaultModelBindingMessageProvider provider, IStringLocalizer localizer)
+        /// <param name="mbErrors">Model binding errors provider</param>
+        public static void SetLocalizedModelBindingErrorMessages(this DefaultModelBindingMessageProvider provider, IStringLocalizer localizer, IModelBindingErrorMessagesProvider mbErrors)
         {
             provider.SetAttemptedValueIsInvalidAccessor((x, y)
-                => GetLoclizedModelBindingError(localizer, "The value '{0}' is not valid for {1}.", x, y));
+                => GetLoclizedModelBindingError(localizer, mbErrors.AttemptedValueIsInvalidAccessor, x, y));
 
             provider.SetMissingBindRequiredValueAccessor((x)
-                => GetLoclizedModelBindingError(localizer, "A value for the '{0}' parameter or property was not provided.", x));
+                => GetLoclizedModelBindingError(localizer, mbErrors.MissingBindRequiredValueAccessor, x));
 
             provider.SetMissingKeyOrValueAccessor(()
-                => GetLoclizedModelBindingError(localizer, "A value is required."));
+                => GetLoclizedModelBindingError(localizer, mbErrors.MissingKeyOrValueAccessor));
 
             provider.SetMissingRequestBodyRequiredValueAccessor(()
-                => GetLoclizedModelBindingError(localizer, "A non-empty request body is required."));
+                => GetLoclizedModelBindingError(localizer, mbErrors.MissingRequestBodyRequiredValueAccessor));
 
             provider.SetNonPropertyAttemptedValueIsInvalidAccessor((x)
-                => GetLoclizedModelBindingError(localizer, "The value '{0}' is not valid.", x));
+                => GetLoclizedModelBindingError(localizer, mbErrors.NonPropertyAttemptedValueIsInvalidAccessor, x));
 
             provider.SetNonPropertyUnknownValueIsInvalidAccessor(()
-                => GetLoclizedModelBindingError(localizer, "The supplied value is invalid."));
+                => GetLoclizedModelBindingError(localizer, mbErrors.NonPropertyUnknownValueIsInvalidAccessor));
 
             provider.SetNonPropertyValueMustBeANumberAccessor(()
-                => GetLoclizedModelBindingError(localizer, "The field must be a number."));
+                => GetLoclizedModelBindingError(localizer, mbErrors.NonPropertyValueMustBeANumberAccessor));
 
             provider.SetUnknownValueIsInvalidAccessor((x)
-                => GetLoclizedModelBindingError(localizer, "The supplied value is invalid for {0}.", x));
+                => GetLoclizedModelBindingError(localizer, mbErrors.UnknownValueIsInvalidAccessor, x));
 
             provider.SetValueIsInvalidAccessor((x)
-                => GetLoclizedModelBindingError(localizer, "The value '{0}' is invalid.", x));
+                => GetLoclizedModelBindingError(localizer, mbErrors.ValueIsInvalidAccessor, x));
 
             provider.SetValueMustBeANumberAccessor((x)
-                => GetLoclizedModelBindingError(localizer, "The field {0} must be a number.", x));
+                => GetLoclizedModelBindingError(localizer, mbErrors.ValueMustBeANumberAccessor, x));
 
             provider.SetValueMustNotBeNullAccessor((x)
-                => GetLoclizedModelBindingError(localizer, "The value '{0}' is invalid.", x));
+                => GetLoclizedModelBindingError(localizer, mbErrors.ValueMustNotBeNullAccessor, x));
         }
 
         private static string GetLoclizedModelBindingError(IStringLocalizer localizer, string code, params object[] args)

--- a/XLocalizer/XLocalizer.csproj
+++ b/XLocalizer/XLocalizer.csproj
@@ -15,6 +15,8 @@
 		<PackageTags>asp.net,core,razor,mvc,localization,globalization,client side,validation,translation,autokeyadding</PackageTags>
 		<PackageReleaseNotes>
 			- Ex validation attributes configured as public
+			- New: IModelBindingErrorMessagesProvide, use to override default model binding error messages
+			- New: IIdentityErrorMessagesProvide, use to override default identity describer error messages
 			Release notes: https://github.com/LazZiya/XLocalizer/releases
 		</PackageReleaseNotes>
 		<Version>1.0.0-preview3</Version>

--- a/XLocalizer/XLocalizer.xml
+++ b/XLocalizer/XLocalizer.xml
@@ -951,6 +951,13 @@
             </summary>
             <returns></returns>
         </member>
+        <member name="T:XLocalizer.ModelBinding.DefaultModelBindingErrorMessagesProvider">
+            <summary>
+            Class to provide custom default model binding error messages.
+            Messages can be provided in any culture, so user can provide localized error messages here,
+            but the default request culture in startup must be configured same as messages culture.
+            </summary>
+        </member>
         <member name="T:XLocalizer.ModelBinding.DependencyInjection">
             <summary>
             Extesnions for adding DataAnnotation Localization
@@ -963,17 +970,80 @@
             <param name="builder"></param>
             <returns></returns>
         </member>
+        <member name="T:XLocalizer.ModelBinding.IModelBindingErrorMessagesProvider">
+            <summary>
+            Interface to provide custom default model binding error messages.
+            Messages can be provided in any culture, so user can provide localized error messages here,
+            but the default request culture in startup must be configured same as messages culture.
+            </summary>
+        </member>
+        <member name="P:XLocalizer.ModelBinding.IModelBindingErrorMessagesProvider.AttemptedValueIsInvalidAccessor">
+            <summary>
+            "The value '{0}' is not valid for {1}."
+            </summary>
+        </member>
+        <member name="P:XLocalizer.ModelBinding.IModelBindingErrorMessagesProvider.MissingBindRequiredValueAccessor">
+            <summary>
+            "A value for the '{0}' parameter or property was not provided."
+            </summary>
+        </member>
+        <member name="P:XLocalizer.ModelBinding.IModelBindingErrorMessagesProvider.MissingKeyOrValueAccessor">
+            <summary>
+            "A value is required."
+            </summary>
+        </member>
+        <member name="P:XLocalizer.ModelBinding.IModelBindingErrorMessagesProvider.MissingRequestBodyRequiredValueAccessor">
+            <summary>
+            "A non-empty request body is required."
+            </summary>
+        </member>
+        <member name="P:XLocalizer.ModelBinding.IModelBindingErrorMessagesProvider.NonPropertyAttemptedValueIsInvalidAccessor">
+            <summary>
+            "The value '{0}' is not valid."
+            </summary>
+        </member>
+        <member name="P:XLocalizer.ModelBinding.IModelBindingErrorMessagesProvider.NonPropertyUnknownValueIsInvalidAccessor">
+            <summary>
+            "The supplied value is invalid."
+            </summary>
+        </member>
+        <member name="P:XLocalizer.ModelBinding.IModelBindingErrorMessagesProvider.NonPropertyValueMustBeANumberAccessor">
+            <summary>
+            "The field must be a number."
+            </summary>
+        </member>
+        <member name="P:XLocalizer.ModelBinding.IModelBindingErrorMessagesProvider.UnknownValueIsInvalidAccessor">
+            <summary>
+            "The supplied value is invalid for {0}."
+            </summary>
+        </member>
+        <member name="P:XLocalizer.ModelBinding.IModelBindingErrorMessagesProvider.ValueIsInvalidAccessor">
+            <summary>
+            "The value '{0}' is invalid."
+            </summary>
+        </member>
+        <member name="P:XLocalizer.ModelBinding.IModelBindingErrorMessagesProvider.ValueMustBeANumberAccessor">
+            <summary>
+            "The field {0} must be a number."
+            </summary>
+        </member>
+        <member name="P:XLocalizer.ModelBinding.IModelBindingErrorMessagesProvider.ValueMustNotBeNullAccessor">
+            <summary>
+            "The value '{0}' is invalid."
+            </summary>
+        </member>
         <member name="T:XLocalizer.ModelBinding.ModelBindingErrorsExtensions">
             <summary>
             Original messages obtained from <a href="https://github.com/aspnet/AspNetCore/blob/master/src/Mvc/Mvc.Core/src/Resources.resx"/>
             </summary>
         </member>
-        <member name="M:XLocalizer.ModelBinding.ModelBindingErrorsExtensions.SetLocalizedModelBindingErrorMessages(Microsoft.AspNetCore.Mvc.ModelBinding.Metadata.DefaultModelBindingMessageProvider,Microsoft.Extensions.Localization.IStringLocalizer)">
+        <member name="M:XLocalizer.ModelBinding.ModelBindingErrorsExtensions.SetLocalizedModelBindingErrorMessages(Microsoft.AspNetCore.Mvc.ModelBinding.Metadata.DefaultModelBindingMessageProvider,Microsoft.Extensions.Localization.IStringLocalizer,XLocalizer.ModelBinding.IModelBindingErrorMessagesProvider)">
             <summary>
             Use DB for localization
             </summary>
             <param name="provider"></param>
             <param name="localizer">localizer factory</param>
+            <param name="mbErrors">Model binding errors provider</param>
         </member>
         <member name="T:XLocalizer.Resx.ResxElement">
             <summary>

--- a/XLocalizer/XLocalizer.xml
+++ b/XLocalizer/XLocalizer.xml
@@ -186,12 +186,13 @@
             Adapter for providing a localized error message for <see cref="T:XLocalizer.DataAnnotations.ExRangeAttribute"/>
             </summary>
         </member>
-        <member name="M:XLocalizer.DataAnnotations.Adapters.ExRangeAttributeAdapter.#ctor(XLocalizer.DataAnnotations.ExRangeAttribute,Microsoft.Extensions.Localization.IStringLocalizer)">
+        <member name="M:XLocalizer.DataAnnotations.Adapters.ExRangeAttributeAdapter.#ctor(XLocalizer.DataAnnotations.ExRangeAttribute,Microsoft.Extensions.Localization.IStringLocalizer,XLocalizer.DataAnnotations.IDataAnnotationsMessagesProvider)">
             <summary>
             Initialize a new instance of <see cref="T:XLocalizer.DataAnnotations.Adapters.ExRangeAttributeAdapter"/>
             </summary>
             <param name="attribute"></param>
             <param name="stringLocalizer"></param>
+            <param name="errProvider"></param>
         </member>
         <member name="M:XLocalizer.DataAnnotations.Adapters.ExRangeAttributeAdapter.AddValidation(Microsoft.AspNetCore.Mvc.ModelBinding.Validation.ClientModelValidationContext)">
             <summary>
@@ -211,12 +212,13 @@
             Adapter for providing a localized error message for <see cref="T:XLocalizer.DataAnnotations.ExRegularExpressionAttribute"/>
             </summary>
         </member>
-        <member name="M:XLocalizer.DataAnnotations.Adapters.ExRegularExpressionAttributeAdapter.#ctor(XLocalizer.DataAnnotations.ExRegularExpressionAttribute,Microsoft.Extensions.Localization.IStringLocalizer)">
+        <member name="M:XLocalizer.DataAnnotations.Adapters.ExRegularExpressionAttributeAdapter.#ctor(XLocalizer.DataAnnotations.ExRegularExpressionAttribute,Microsoft.Extensions.Localization.IStringLocalizer,XLocalizer.DataAnnotations.IDataAnnotationsMessagesProvider)">
             <summary>
             Initialize a new instance of <see cref="T:XLocalizer.DataAnnotations.Adapters.ExRegularExpressionAttributeAdapter"/>
             </summary>
             <param name="attribute"></param>
             <param name="stringLocalizer"></param>
+            <param name="errProvider"></param>
         </member>
         <member name="M:XLocalizer.DataAnnotations.Adapters.ExRegularExpressionAttributeAdapter.AddValidation(Microsoft.AspNetCore.Mvc.ModelBinding.Validation.ClientModelValidationContext)">
             <summary>
@@ -526,6 +528,11 @@
             The value for property '{0}' must be of type '{1}'.
             </summary>
         </member>
+        <member name="T:XLocalizer.DataAnnotations.DefaultDataAnnotationsErrorMessagesProvider">
+            <summary>
+            Original messages obtained from <a href="https://github.com/dotnet/corefx/blob/master/src/System.ComponentModel.Annotations/src/Resources/Strings.resx"/>
+            </summary>
+        </member>
         <member name="T:XLocalizer.DataAnnotations.DependencyInjection">
             <summary>
             Extesnions for adding DataAnnotation Localization
@@ -545,12 +552,13 @@
             A switch to return the relevant Ex attribute or null if no Ex attribute is detected
             </summary>
         </member>
-        <member name="M:XLocalizer.DataAnnotations.ExAttributeAdapterSwitch.GetAttributeAdapter(System.ComponentModel.DataAnnotations.ValidationAttribute,Microsoft.Extensions.Localization.IStringLocalizer)">
+        <member name="M:XLocalizer.DataAnnotations.ExAttributeAdapterSwitch.GetAttributeAdapter(System.ComponentModel.DataAnnotations.ValidationAttribute,Microsoft.Extensions.Localization.IStringLocalizer,XLocalizer.DataAnnotations.IDataAnnotationsMessagesProvider)">
             <summary>
             Get the ex attribute adapter
             </summary>
             <param name="attribute"></param>
             <param name="stringLocalizer"></param>
+            <param name="errProvider"></param>
             <returns></returns>
         </member>
         <member name="T:XLocalizer.DataAnnotations.ExCompareAttribute">
@@ -596,7 +604,7 @@
             Registeres express valdiation attributes
             </summary>
         </member>
-        <member name="M:XLocalizer.DataAnnotations.ExpressValidationAttributeAdapterProvider.#ctor">
+        <member name="M:XLocalizer.DataAnnotations.ExpressValidationAttributeAdapterProvider.#ctor(XLocalizer.DataAnnotations.IDataAnnotationsMessagesProvider)">
             <summary>
             Initialize a new instance of <see cref="T:XLocalizer.DataAnnotations.ExpressValidationAttributeAdapterProvider"/>
             </summary>
@@ -672,6 +680,248 @@
             </summary>
             <param name="maximumLength">The maximum length of a string.</param>
         </member>
+        <member name="T:XLocalizer.DataAnnotations.IDataAnnotationsMessagesProvider">
+            <summary>
+            Interface to provide custom default data annotation error messages.
+            Messages can be provided in any culture, so user can provide localized error messages here,
+            but the default request culture in startup must be configured same as messages culture.
+            </summary>
+        </member>
+        <member name="P:XLocalizer.DataAnnotations.IDataAnnotationsMessagesProvider.ArgumentIsNullOrWhitespace">
+            <summary>
+            The argument '{0}' cannot be null, empty or contain only whitespace.
+            </summary>
+        </member>
+        <member name="P:XLocalizer.DataAnnotations.IDataAnnotationsMessagesProvider.AssociatedMetadataTypeTypeDescriptor_MetadataTypeContainsUnknownProperties">
+            <summary>
+            The associated metadata type for type '{0}' contains the following unknown properties or fields: {1}. Please make sure that the names of these members match the names of the properties on the main type.
+            </summary>
+        </member>
+        <member name="P:XLocalizer.DataAnnotations.IDataAnnotationsMessagesProvider.AttributeStore_Unknown_Property">
+            <summary>
+            The type '{0}' does not contain a property named '{1}'.
+            </summary>
+        </member>
+        <member name="P:XLocalizer.DataAnnotations.IDataAnnotationsMessagesProvider.Common_PropertyNotFound">
+            <summary>
+            The property {0}.{1} could not be found.
+            </summary>
+        </member>
+        <member name="P:XLocalizer.DataAnnotations.IDataAnnotationsMessagesProvider.CompareAttribute_MustMatch">
+            <summary>
+            '{0}' and '{1}' do not match.
+            </summary>
+        </member>
+        <member name="P:XLocalizer.DataAnnotations.IDataAnnotationsMessagesProvider.CompareAttribute_UnknownProperty">
+            <summary>
+            Could not find a property named {0}.
+            </summary>
+        </member>
+        <member name="P:XLocalizer.DataAnnotations.IDataAnnotationsMessagesProvider.CreditCardAttribute_Invalid">
+            <summary>
+            The {0} field is not a valid credit card number.
+            </summary>
+        </member>
+        <member name="P:XLocalizer.DataAnnotations.IDataAnnotationsMessagesProvider.CustomValidationAttribute_Type_Conversion_Failed">
+            <summary>
+            Could not convert the value of type '{0}' to '{1}' as expected by method {2}.{3}.
+            </summary>
+        </member>
+        <member name="P:XLocalizer.DataAnnotations.IDataAnnotationsMessagesProvider.CustomValidationAttribute_Type_Must_Be_Public">
+            <summary>
+            The custom validation type '{0}' must be public.
+            </summary>
+        </member>
+        <member name="P:XLocalizer.DataAnnotations.IDataAnnotationsMessagesProvider.CustomValidationAttribute_ValidationError">
+            <summary>
+            {0} is not valid.
+            </summary>
+        </member>
+        <member name="P:XLocalizer.DataAnnotations.IDataAnnotationsMessagesProvider.DataTypeAttribute_EmptyDataTypeString">
+            <summary>
+            The custom DataType string cannot be null or empty.
+            </summary>
+        </member>
+        <member name="P:XLocalizer.DataAnnotations.IDataAnnotationsMessagesProvider.DisplayAttribute_PropertyNotSet">
+            <summary>
+            The {0} property has not been set.  Use the {1} method to get the value.
+            </summary>
+        </member>
+        <member name="P:XLocalizer.DataAnnotations.IDataAnnotationsMessagesProvider.EmailAddressAttribute_Invalid">
+            <summary>
+            The {0} field is not a valid e-mail address.
+            </summary>
+        </member>
+        <member name="P:XLocalizer.DataAnnotations.IDataAnnotationsMessagesProvider.EnumDataTypeAttribute_TypeCannotBeNull">
+            <summary>
+            The type provided for EnumDataTypeAttribute cannot be null.
+            </summary>
+        </member>
+        <member name="P:XLocalizer.DataAnnotations.IDataAnnotationsMessagesProvider.EnumDataTypeAttribute_TypeNeedsToBeAnEnum">
+            <summary>
+            The type '{0}' needs to represent an enumeration type.
+            </summary>
+        </member>
+        <member name="P:XLocalizer.DataAnnotations.IDataAnnotationsMessagesProvider.FileExtensionsAttribute_Invalid">
+            <summary>
+            The {0} field only accepts files with the following extensions: {1}
+            </summary>
+        </member>
+        <member name="P:XLocalizer.DataAnnotations.IDataAnnotationsMessagesProvider.LengthAttribute_InvalidValueType">
+            <summary>
+            The field of type {0} must be a string, array or ICollection type.
+            </summary>
+        </member>
+        <member name="P:XLocalizer.DataAnnotations.IDataAnnotationsMessagesProvider.MaxLengthAttribute_InvalidMaxLength">
+            <summary>
+            MaxLengthAttribute must have a Length value that is greater than zero. Use MaxLength() without parameters to indicate that the string or array can have the maximum allowable length.
+            </summary>
+        </member>
+        <member name="P:XLocalizer.DataAnnotations.IDataAnnotationsMessagesProvider.MaxLengthAttribute_ValidationError">
+            <summary>
+            The field {0} must be a string or array type with a maximum length of '{1}'.
+            </summary>
+        </member>
+        <member name="P:XLocalizer.DataAnnotations.IDataAnnotationsMessagesProvider.MetadataTypeAttribute_TypeCannotBeNull">
+            <summary>
+            MetadataClassType cannot be null.
+            </summary>
+        </member>
+        <member name="P:XLocalizer.DataAnnotations.IDataAnnotationsMessagesProvider.MinLengthAttribute_InvalidMinLength">
+            <summary>
+            MinLengthAttribute must have a Length value that is zero or greater.
+            </summary>
+        </member>
+        <member name="P:XLocalizer.DataAnnotations.IDataAnnotationsMessagesProvider.MinLengthAttribute_ValidationError">
+            <summary>
+            The field {0} must be a string or array type with a minimum length of '{1}'.
+            </summary>
+        </member>
+        <member name="P:XLocalizer.DataAnnotations.IDataAnnotationsMessagesProvider.PhoneAttribute_Invalid">
+            <summary>
+            The {0} field is not a valid phone number.
+            </summary>
+        </member>
+        <member name="P:XLocalizer.DataAnnotations.IDataAnnotationsMessagesProvider.RangeAttribute_ArbitraryTypeNotIComparable">
+            <summary>
+            The type {0} must implement {1}.
+            </summary>
+        </member>
+        <member name="P:XLocalizer.DataAnnotations.IDataAnnotationsMessagesProvider.RangeAttribute_MinGreaterThanMax">
+            <summary>
+            The maximum value '{0}' must be greater than or equal to the minimum value '{1}'.
+            </summary>
+        </member>
+        <member name="P:XLocalizer.DataAnnotations.IDataAnnotationsMessagesProvider.RangeAttribute_Must_Set_Min_And_Max">
+            <summary>
+            The minimum and maximum values must be set.
+            </summary>
+        </member>
+        <member name="P:XLocalizer.DataAnnotations.IDataAnnotationsMessagesProvider.RangeAttribute_Must_Set_Operand_Type">
+            <summary>
+            The OperandType must be set when strings are used for minimum and maximum values.
+            </summary>
+        </member>
+        <member name="P:XLocalizer.DataAnnotations.IDataAnnotationsMessagesProvider.RangeAttribute_ValidationError">
+            <summary>
+            The field {0} must be between {1} and {2}.
+            </summary>
+        </member>
+        <member name="P:XLocalizer.DataAnnotations.IDataAnnotationsMessagesProvider.RegexAttribute_ValidationError">
+            <summary>
+            The field {0} must match the regular expression '{1}'.
+            </summary>
+        </member>
+        <member name="P:XLocalizer.DataAnnotations.IDataAnnotationsMessagesProvider.RegularExpressionAttribute_Empty_Pattern">
+            <summary>
+            The pattern must be set to a valid regular expression.
+            </summary>
+        </member>
+        <member name="P:XLocalizer.DataAnnotations.IDataAnnotationsMessagesProvider.RequiredAttribute_ValidationError">
+            <summary>
+            The {0} field is required.
+            </summary>
+        </member>
+        <member name="P:XLocalizer.DataAnnotations.IDataAnnotationsMessagesProvider.StringLengthAttribute_InvalidMaxLength">
+            <summary>
+            The maximum length must be a nonnegative integer.
+            </summary>
+        </member>
+        <member name="P:XLocalizer.DataAnnotations.IDataAnnotationsMessagesProvider.StringLengthAttribute_ValidationError">
+            <summary>
+            The field {0} must be a string with a maximum length of {1}.
+            </summary>
+        </member>
+        <member name="P:XLocalizer.DataAnnotations.IDataAnnotationsMessagesProvider.StringLengthAttribute_ValidationErrorIncludingMinimum">
+            <summary>
+            The field {0} must be a string with a minimum length of {2} and a maximum length of {1}.
+            </summary>
+        </member>
+        <member name="P:XLocalizer.DataAnnotations.IDataAnnotationsMessagesProvider.UIHintImplementation_ControlParameterKeyIsNotAString">
+            <summary>
+            The key parameter at position {0} with value '{1}' is not a string. Every key control parameter must be a string.
+            </summary>
+        </member>
+        <member name="P:XLocalizer.DataAnnotations.IDataAnnotationsMessagesProvider.UIHintImplementation_ControlParameterKeyIsNull">
+            <summary>
+            The key parameter at position {0} is null. Every key control parameter must be a string.
+            </summary>
+        </member>
+        <member name="P:XLocalizer.DataAnnotations.IDataAnnotationsMessagesProvider.UIHintImplementation_ControlParameterKeyOccursMoreThanOnce">
+            <summary>
+            The key parameter at position {0} with value '{1}' occurs more than once.
+            </summary>
+        </member>
+        <member name="P:XLocalizer.DataAnnotations.IDataAnnotationsMessagesProvider.UIHintImplementation_NeedEvenNumberOfControlParameters">
+            <summary>
+            The number of control parameters must be even.
+            </summary>
+        </member>
+        <member name="P:XLocalizer.DataAnnotations.IDataAnnotationsMessagesProvider.UrlAttribute_Invalid">
+            <summary>
+            The {0} field is not a valid fully-qualified http, https, or ftp URL.
+            </summary>
+        </member>
+        <member name="P:XLocalizer.DataAnnotations.IDataAnnotationsMessagesProvider.ValidationAttribute_Cannot_Set_ErrorMessage_And_Resource">
+            <summary>
+            Either ErrorMessageString or ErrorMessageResourceName must be set, but not both.
+            </summary>
+        </member>
+        <member name="P:XLocalizer.DataAnnotations.IDataAnnotationsMessagesProvider.ValidationAttribute_IsValid_NotImplemented">
+            <summary>
+            IsValid(object value) has not been implemented by this class.  The preferred entry point is GetValidationResult() and classes should override IsValid(object value, ValidationContext context).
+            </summary>
+        </member>
+        <member name="P:XLocalizer.DataAnnotations.IDataAnnotationsMessagesProvider.ValidationAttribute_NeedBothResourceTypeAndResourceName">
+            <summary>
+            Both ErrorMessageResourceType and ErrorMessageResourceName need to be set on this attribute.
+            </summary>
+        </member>
+        <member name="P:XLocalizer.DataAnnotations.IDataAnnotationsMessagesProvider.ValidationAttribute_ResourcePropertyNotStringType">
+            <summary>
+            The property '{0}' on resource type '{1}' is not a string type.
+            </summary>
+        </member>
+        <member name="P:XLocalizer.DataAnnotations.IDataAnnotationsMessagesProvider.ValidationAttribute_ResourceTypeDoesNotHaveProperty">
+            <summary>
+            The resource type '{0}' does not have an accessible static property named '{1}'.
+            </summary>
+        </member>
+        <member name="P:XLocalizer.DataAnnotations.IDataAnnotationsMessagesProvider.ValidationAttribute_ValidationError">
+            <summary>
+            The field {0} is invalid.
+            </summary>
+        </member>
+        <member name="P:XLocalizer.DataAnnotations.IDataAnnotationsMessagesProvider.Validator_InstanceMustMatchValidationContextInstance">
+            <summary>
+            The instance provided must match the ObjectInstance on the ValidationContext supplied.
+            </summary>
+        </member>
+        <member name="P:XLocalizer.DataAnnotations.IDataAnnotationsMessagesProvider.Validator_Property_Value_Wrong_Type">
+            <summary>
+            The value for property '{0}' must be of type '{1}'.
+            </summary>
+        </member>
         <member name="T:XLocalizer.DependencyInjection">
             <summary>
             DI
@@ -713,6 +963,11 @@
             <param name="options"></param>
             <returns></returns>
         </member>
+        <member name="T:XLocalizer.Identity.DefaultIdentityErrorsProvider">
+            <summary>
+            Default identity errors provider
+            </summary>
+        </member>
         <member name="T:XLocalizer.Identity.DependencyInjection">
             <summary>
             Extesnions for adding Identity errors localization
@@ -731,11 +986,12 @@
             Original mesages obtained from: https://github.com/aspnet/AspNetCore/blob/master/src/Identity/Extensions.Core/src/Resources.resx
             </summary>
         </member>
-        <member name="M:XLocalizer.Identity.IdentityErrorsLocalizer.#ctor(Microsoft.Extensions.Localization.IStringLocalizer)">
+        <member name="M:XLocalizer.Identity.IdentityErrorsLocalizer.#ctor(Microsoft.Extensions.Localization.IStringLocalizer,XLocalizer.Identity.IIdentityErrorMessagesProvider)">
             <summary>
             Initialize identity erroors localization based on DB locailzer
             </summary>
             <param name="localizer"></param>
+            <param name="errProvider"></param>
         </member>
         <member name="M:XLocalizer.Identity.IdentityErrorsLocalizer.DuplicateEmail(System.String)">
             <summary>
@@ -878,6 +1134,123 @@
             "An unknown failure has occurred."
             </summary>
             <returns></returns>
+        </member>
+        <member name="T:XLocalizer.Identity.IIdentityErrorMessagesProvider">
+            <summary>
+            Interface to provide custom default identity error messages.
+            Messages can be provided in any culture, so user can provide localized error messages here,
+            but the default request culture in startup must be configured same as messages culture.
+            </summary>
+        </member>
+        <member name="P:XLocalizer.Identity.IIdentityErrorMessagesProvider.DuplicateEmail">
+            <summary>
+            "Email '{0}' is already taken."
+            </summary>
+        </member>
+        <member name="P:XLocalizer.Identity.IIdentityErrorMessagesProvider.DuplicateUserName">
+            <summary>
+            "User name '{0}' is already taken."
+            </summary>
+        </member>
+        <member name="P:XLocalizer.Identity.IIdentityErrorMessagesProvider.InvalidEmail">
+            <summary>
+            "Email '{0}' is invalid."
+            </summary>
+        </member>
+        <member name="P:XLocalizer.Identity.IIdentityErrorMessagesProvider.DuplicateRoleName">
+            <summary>
+            "Role name '{0}' is already taken."
+            </summary>
+        </member>
+        <member name="P:XLocalizer.Identity.IIdentityErrorMessagesProvider.InvalidRoleName">
+            <summary>
+            "Role name '{0}' is invalid."
+            </summary>
+        </member>
+        <member name="P:XLocalizer.Identity.IIdentityErrorMessagesProvider.InvalidToken">
+            <summary>
+            "Invalid token."
+            </summary>
+        </member>
+        <member name="P:XLocalizer.Identity.IIdentityErrorMessagesProvider.InvalidUserName">
+            <summary>
+            "User name '{0}' is invalid, can only contain letters or digits."
+            </summary>
+        </member>
+        <member name="P:XLocalizer.Identity.IIdentityErrorMessagesProvider.LoginAlreadyAssociated">
+            <summary>
+            "A user with this login already exists."
+            </summary>
+        </member>
+        <member name="P:XLocalizer.Identity.IIdentityErrorMessagesProvider.PasswordMismatch">
+            <summary>
+            "Incorrect password."
+            </summary>
+        </member>
+        <member name="P:XLocalizer.Identity.IIdentityErrorMessagesProvider.PasswordRequiresDigit">
+            <summary>
+            "Passwords must have at least one digit ('0'-'9')."
+            </summary>
+        </member>
+        <member name="P:XLocalizer.Identity.IIdentityErrorMessagesProvider.PasswordRequiresLower">
+            <summary>
+            "Passwords must have at least one lowercase ('a'-'z')."
+            </summary>
+        </member>
+        <member name="P:XLocalizer.Identity.IIdentityErrorMessagesProvider.PasswordRequiresNonAlphanumeric">
+            <summary>
+            "Passwords must have at least one non alphanumeric character."
+            </summary>
+        </member>
+        <member name="P:XLocalizer.Identity.IIdentityErrorMessagesProvider.PasswordRequiresUniqueChars">
+            <summary>
+            "Passwords must use at least {0} different characters."
+            </summary>
+        </member>
+        <member name="P:XLocalizer.Identity.IIdentityErrorMessagesProvider.PasswordRequiresUpper">
+            <summary>
+            "Passwords must have at least one uppercase ('A'-'Z')."
+            </summary>
+        </member>
+        <member name="P:XLocalizer.Identity.IIdentityErrorMessagesProvider.PasswordTooShort">
+            <summary>
+            "Passwords must be at least {0} characters."
+            </summary>
+        </member>
+        <member name="P:XLocalizer.Identity.IIdentityErrorMessagesProvider.UserAlreadyHasPassword">
+            <summary>
+            "User already has a password set."
+            </summary>
+        </member>
+        <member name="P:XLocalizer.Identity.IIdentityErrorMessagesProvider.UserAlreadyInRole">
+            <summary>
+            "User already in role '{0}'."
+            </summary>
+        </member>
+        <member name="P:XLocalizer.Identity.IIdentityErrorMessagesProvider.UserNotInRole">
+            <summary>
+            "User is not in role '{0}'."
+            </summary>
+        </member>
+        <member name="P:XLocalizer.Identity.IIdentityErrorMessagesProvider.UserLockoutNotEnabled">
+            <summary>
+            "Lockout is not enabled for this user."
+            </summary>
+        </member>
+        <member name="P:XLocalizer.Identity.IIdentityErrorMessagesProvider.RecoveryCodeRedemptionFailed">
+            <summary>
+            "Recovery code redemption failed."
+            </summary>
+        </member>
+        <member name="P:XLocalizer.Identity.IIdentityErrorMessagesProvider.ConcurrencyFailure">
+            <summary>
+            "Optimistic concurrency failure, object has been modified."
+            </summary>
+        </member>
+        <member name="P:XLocalizer.Identity.IIdentityErrorMessagesProvider.DefaultError">
+            <summary>
+            "An unknown failure has occurred."
+            </summary>
         </member>
         <member name="T:XLocalizer.IXHtmlLocalizerFactory">
             <summary>


### PR DESCRIPTION
- Ex validation attributes configured as public
- New: IModelBindingErrorMessagesProvide, use to override default model binding error messages
- New: IIdentityErrorMessagesProvide, use to override default identity describer error messages