### PR TITLE
V next

### DIFF
--- a/XLocalizer/XLocalizer.csproj
+++ b/XLocalizer/XLocalizer.csproj
@@ -14,17 +14,17 @@
 		<PackageIcon>icon.png</PackageIcon>
 		<PackageTags>asp.net,core,razor,mvc,localization,globalization,client side,validation,translation,autokeyadding</PackageTags>
 		<PackageReleaseNotes>
-      Improvements
-      - Performance imrovements 
-      - Bypass localizing if current culture is same as TranslateFromCulture
-      See all docs: https://docs.ziyad.info/en/XLocalizer/v1.0/index.md
+			Improvements
+			- Removed deprected property UseExpressValidationAttributes. See https://docs.ziyad.info/en/XLocalizer/v1.0/localizing-validation-attributes-errors.md
+			- Bypass localizing if current culture is same as TranslateFromCulture
+			See all docs: https://docs.ziyad.info/en/XLocalizer/v1.0/index.md
 
-      Release notes: https://github.com/LazZiya/XLocalizer/releases
-    </PackageReleaseNotes>
-		<VersionPrefix>1.0.2</VersionPrefix>
-		<VersionSuffix></VersionSuffix>
-		<AssemblyVersion>1.0.2.0</AssemblyVersion>
-		<FileVersion>1.0.2.0</FileVersion>
+			Release notes: https://github.com/LazZiya/XLocalizer/releases
+		</PackageReleaseNotes>
+		<VersionPrefix>1.0.3</VersionPrefix>
+		<VersionSuffix>test-0</VersionSuffix>
+		<AssemblyVersion>1.0.3.0</AssemblyVersion>
+		<FileVersion>1.0.3.0</FileVersion>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<PackageIconUrl>https://github.com/LazZiya/XLocalizer/raw/master/XLocalizer/files/icon.png</PackageIconUrl>

--- a/XLocalizer/XLocalizer.csproj
+++ b/XLocalizer/XLocalizer.csproj
@@ -16,7 +16,7 @@
 		<PackageReleaseNotes>
 			Improvements
 			- Removed deprected property UseExpressValidationAttributes. See https://docs.ziyad.info/en/XLocalizer/v1.0/localizing-validation-attributes-errors.md
-			- Bypass localizing if current culture is same as TranslateFromCulture
+			- New option LocalizeDefatulCultre: Use to enable/disable localizing default culture
 			See all docs: https://docs.ziyad.info/en/XLocalizer/v1.0/index.md
 
 			Release notes: https://github.com/LazZiya/XLocalizer/releases

--- a/XLocalizer/XLocalizer.csproj
+++ b/XLocalizer/XLocalizer.csproj
@@ -22,7 +22,7 @@
 			Release notes: https://github.com/LazZiya/XLocalizer/releases
 		</PackageReleaseNotes>
 		<VersionPrefix>1.0.3</VersionPrefix>
-		<VersionSuffix>test-0</VersionSuffix>
+		<VersionSuffix></VersionSuffix>
 		<AssemblyVersion>1.0.3.0</AssemblyVersion>
 		<FileVersion>1.0.3.0</FileVersion>
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>

--- a/XLocalizer/XLocalizer.xml
+++ b/XLocalizer/XLocalizer.xml
@@ -1748,11 +1748,6 @@
             The path to the resources folder e.g. "LocalizationResources"
             </summary>
         </member>
-        <member name="P:XLocalizer.XLocalizerOptions.UseExpressValidationAttributes">
-            <summary>
-            Express validation attributes are deprected. Use default attributes instead. See <a href="https://docs.ziyad.info/en/XLocalizer/v1.0/localizing-validation-attributes-errors.md">Localizing Data Annotations</a>
-            </summary>
-        </member>
         <member name="P:XLocalizer.XLocalizerOptions.AutoAddKeys">
             <summary>
             If the key string is not found in the DB, it will be inserted autoamtically to the DB.
@@ -1776,6 +1771,12 @@
         <member name="P:XLocalizer.XLocalizerOptions.TranslateFromCulture">
             <summary>
             The culture name to translate from, if not set default request culture will be used.
+            </summary>
+        </member>
+        <member name="P:XLocalizer.XLocalizerOptions.LocalizeDefaultCulture">
+            <summary>
+            When set to true the default culture (or source translation culture) will be localized (use case; when using CODE keys instead of texts.).
+            Default value is false (default culture not localized).
             </summary>
         </member>
         <member name="P:XLocalizer.XLocalizerOptions.ValidationErrors">

--- a/XLocalizer/XLocalizerOptions.cs
+++ b/XLocalizer/XLocalizerOptions.cs
@@ -38,6 +38,12 @@ namespace XLocalizer
         public string TranslateFromCulture { get; set; }
 
         /// <summary>
+        /// When set to true the default culture (or source translation culture) will be localized (use case; when using CODE keys instead of texts.).
+        /// Default value is false (default culture not localized).
+        /// </summary>
+        public bool LocalizeDefaultCulture { get; set; } = false;
+
+        /// <summary>
         /// Customize all valdiation error messages.
         /// </summary>
         public ValidationErrors ValidationErrors { get; set; } = new ValidationErrors();

--- a/XLocalizer/XLocalizerOptions.cs
+++ b/XLocalizer/XLocalizerOptions.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using XLocalizer.ErrorMessages;
+﻿using XLocalizer.ErrorMessages;
 
 namespace XLocalizer
 {
@@ -12,12 +11,6 @@ namespace XLocalizer
         /// The path to the resources folder e.g. "LocalizationResources"
         /// </summary>
         public string ResourcesPath { get; set; } = "LocalizationResources";
-
-        /// <summary>
-        /// Express validation attributes are deprected. Use default attributes instead. See <a href="https://docs.ziyad.info/en/XLocalizer/v1.0/localizing-validation-attributes-errors.md">Localizing Data Annotations</a>
-        /// </summary>
-        [Obsolete("Express validation attributes are deprected. Use default attributes instead. See https://docs.ziyad.info/en/XLocalizer/v1.0/localizing-validation-attributes-errors.md")]
-        public bool UseExpressValidationAttributes { get; set; } = false;
 
         /// <summary>
         /// If the key string is not found in the DB, it will be inserted autoamtically to the DB.

--- a/XLocalizer/XStringLocalizer.cs
+++ b/XLocalizer/XStringLocalizer.cs
@@ -87,8 +87,11 @@ namespace XLocalizer
 
         private LocalizedString GetLocalizedString(string name, params object[] arguments)
         {
-            // Option 0: If current culture is same as translation culture just return the key back
-            if (_transCulture.Equals(CultureInfo.CurrentCulture.Name, StringComparison.OrdinalIgnoreCase))
+            var currentCulture = CultureInfo.CurrentCulture.Name;
+
+            // Option 0: Skip localization if:
+            // LocalizeDefaultCulture == false and currentCulture == _transCulture
+            if (!_options.LocalizeDefaultCulture && _transCulture.Equals(currentCulture, StringComparison.OrdinalIgnoreCase))
             {
                 return new LocalizedString(name, string.Format(name, arguments), true, string.Empty);
             }
@@ -114,7 +117,7 @@ namespace XLocalizer
             var availableInTranslate = false;
             if (_options.AutoTranslate)
             {
-                availableInTranslate = _translator.TryTranslate(_transCulture, CultureInfo.CurrentCulture.Name, name, out value);
+                availableInTranslate = _translator.TryTranslate(_transCulture, currentCulture, name, out value);
                 if (availableInTranslate)
                 {
                     // Add to cache

--- a/XLocalizer/XStringLocalizer.cs
+++ b/XLocalizer/XStringLocalizer.cs
@@ -87,11 +87,12 @@ namespace XLocalizer
 
         private LocalizedString GetLocalizedString(string name, params object[] arguments)
         {
-            var currentCulture = CultureInfo.CurrentCulture.Name;
+            var _targetCulture = CultureInfo.CurrentCulture.Name;
+            var _targetEqualSource = _transCulture.Equals(_targetCulture, StringComparison.OrdinalIgnoreCase);
 
             // Option 0: Skip localization if:
             // LocalizeDefaultCulture == false and currentCulture == _transCulture
-            if (!_options.LocalizeDefaultCulture && _transCulture.Equals(currentCulture, StringComparison.OrdinalIgnoreCase))
+            if (!_options.LocalizeDefaultCulture && _targetEqualSource)
             {
                 return new LocalizedString(name, string.Format(name, arguments), true, string.Empty);
             }
@@ -114,10 +115,12 @@ namespace XLocalizer
             }
 
             // Option 3: Try online translation service
+            //           and don't do online translation if target == source culture,
+            //           because online tranlsation services requires two different cultures.
             var availableInTranslate = false;
-            if (_options.AutoTranslate)
+            if (_options.AutoTranslate && !_targetEqualSource)
             {
-                availableInTranslate = _translator.TryTranslate(_transCulture, currentCulture, name, out value);
+                availableInTranslate = _translator.TryTranslate(_transCulture, _targetCulture, name, out value);
                 if (availableInTranslate)
                 {
                     // Add to cache
@@ -125,9 +128,10 @@ namespace XLocalizer
                 }
             }
 
-            // Save to source file when AutoAdd is anebled and
-            // translation success or AutoTranslate is off
-            if (_options.AutoAddKeys && (availableInTranslate || !_options.AutoTranslate))
+            // Save to source file when AutoAdd is anebled and:
+            // A:translation success or, B: AutoTranslate is off or, C: Target and source cultures are same
+            // option C: useful when we use code keys to localize defatul culture as well
+            if (_options.AutoAddKeys && (availableInTranslate || !_options.AutoTranslate || _targetEqualSource))
             {
                 bool savedToResource = _provider.TrySetValue<TResource>(name, value ?? name, "Created by XLocalizer");
                 _logger.LogInformation($"Save resource to file, status: '{savedToResource}', key: '{name}', value: '{value ?? name}'");


### PR DESCRIPTION
### Improvements

- Removed deprected property UseExpressValidationAttributes. For latest setup see [Localizing Validation Attribute Errors](https://docs.ziyad.info/en/XLocalizer/v1.0/localizing-validation-attributes-errors.md)
- New option LocalizeDefaultCultre: Use to enable/disable localizing default culture (fixes #19 )